### PR TITLE
Update string comparison format for version check

### DIFF
--- a/Casks/neardrop.rb
+++ b/Casks/neardrop.rb
@@ -7,7 +7,7 @@ cask "neardrop" do
   desc "Unofficial Google Nearby Share app"
   homepage "https://github.com/grishka/NearDrop/"
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "NearDrop.app"
 


### PR DESCRIPTION
When running `brew update && brew upgrade` I got the following:
> Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
Please report this issue to the grishka/homebrew-grishka tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/grishka/homebrew-grishka/Casks/neardrop.rb:10

This PR updates the string comparison format to match the deprecation message.